### PR TITLE
Handle empty wallets

### DIFF
--- a/bin/get-balances.ts
+++ b/bin/get-balances.ts
@@ -62,8 +62,12 @@ function logDebug(message: string) {
 
     logDebug(`Balance fetch completed in ${duration}ms`);
 
-    for (const { asset, amount } of resp.balances) {
-      console.log(`${asset}: ${amount}`);
+    if (resp.balances.length === 0) {
+      console.log('No balances found');
+    } else {
+      for (const { asset, amount } of resp.balances) {
+        console.log(`${asset}: ${amount}`);
+      }
     }
 
     process.exit(0);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/lunch-money/ethereum-to-lunch-money/issues"
   },
   "homepage": "https://github.com/lunch-money/ethereum-to-lunch-money#README",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "keywords": [
     "lunch money",

--- a/src/client.ts
+++ b/src/client.ts
@@ -345,7 +345,8 @@ export const createEthereumWalletClient = (
       let customProvider: EthersProviderLike = providers[0].customProvider as EthersProviderLike;
       let providerName = providers[0].name;
       debug(`Attempting lookup using primary provider: ${providerName}`);
-      while (result.balances.length === 0) {
+      let balanceFound = false;
+      while (!balanceFound) {
         try {
           result = await internalGetBalances(
             this,
@@ -355,6 +356,7 @@ export const createEthereumWalletClient = (
             customProvider,
             obscuredWalletAddress,
           );
+          balanceFound = true;
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           debug(`Error getting balances using provider ${providerName}: ${errorMessage}`);


### PR DESCRIPTION
The fallback logic to try secondary providers when primary providers fail used the presence of balances as the breakout condition of a while loop.  This caused an infinite loop on empty walltes (which return a valid, empty results array).

This change utilizes a boolean that is set to true when getBalances is called.   It has been tested on an empty wallet that was created to reproduce the original error condition.