### PR TITLE
Migrate Etherscan API key validation to V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/lunch-money/ethereum-to-lunch-money/issues"
   },
   "homepage": "https://github.com/lunch-money/ethereum-to-lunch-money#README",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "keywords": [
     "lunch money",

--- a/src/ethereum_init.ts
+++ b/src/ethereum_init.ts
@@ -360,7 +360,7 @@ class EthereumInitializationService {
         this.logDebug(`Found an Etherscan key (masked): ${this.maskKey(process.env.ETHERSCAN_API_KEY)}`);
         apiKeyTestInfo.push({
           provider: 'Etherscan',
-          url: `https://api.etherscan.io/api?module=account&action=balance&address=${testAddress}&tag=latest&apikey=${process.env.ETHERSCAN_API_KEY}`,
+          url: `https://api.etherscan.io/v2/api?chainid=1&module=account&action=balance&address=${testAddress}&tag=latest&apikey=${process.env.ETHERSCAN_API_KEY}`,
           responseHandler: this.handleEtherscanResponse,
         });
       }
@@ -381,7 +381,7 @@ class EthereumInitializationService {
   private handleEtherscanResponse = async (response: Response): Promise<ProviderInfo> => {
     const data = await response.json();
     if (data.status === '0' && data.message === 'NOTOK') {
-      throw new Error(`Etherscan API error: ${data.result}`);
+      throw new Error(`Etherscan V2 API error: ${data.result}`);
     }
     console.log('[DEBUG_ETHEREUM] Etherscan API key test: SUCCESS');
     return {


### PR DESCRIPTION
- Update API key validation endpoint from V1 to V2 format
- Add chainid=1 parameter to validation URL
- Update error message to reference V2 API for consistency
- Bump version to 2.0.2