### PR TITLE
Upgrade ethers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/lunch-money/ethereum-to-lunch-money/issues"
   },
   "homepage": "https://github.com/lunch-money/ethereum-to-lunch-money#README",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "keywords": [
     "lunch money",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@mycrypto/eth-scan": "^3.5.3",
-    "ethers": "^6.13.5"
+    "ethers": "^6.16.0"
   },
   "types": "./dist/cjs/src/main.d.ts",
   "directories": {

--- a/run-scenarios.mjs
+++ b/run-scenarios.mjs
@@ -60,6 +60,7 @@ function runTest(scenario, failOnError) {
     const options = { env };
 
     console.log(`Running: ${scenario.description} with DEBUG_ETHEREUM_FAIL_ON_ERROR=${failOnError}`);
+    console.log(`Expected Result: ${scenario.expected[failOnError]}`);
     exec(command, options, (error, stdout, stderr) => {
       const result = {
         description: scenario.description,


### PR DESCRIPTION
Bump ethers from 6.13 to 6.16.  Required to continue using Alchemy as a service provider.

Our records show that your application is still making RPC requests to the legacy endpoint alchemyapi.io, which was deprecated in 2021.

Please migrate to our current endpoint, [g.alchemy.com](http://g.alchemy.com/), which offers significant latency improvements while maintaining the same authentication model and API functionality.

If you are using our legacy RPC endpoint (e.g. <network>.alchemyapi.io), then you need to migrate to the new endpoint <network>.g.alchemy.com.

If you are using the Ethers.js package, please ensure you are running v6.16.0 or later, which routes requests through the current [g.alchemy.com](http://g.alchemy.com/) domain.

To ensure uninterrupted service, please complete your migration before the full shutdown of the legacy endpoint on January 31, 2026.