### PR TITLE
Jp/handle etherscan pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Tweaking this to about 1000-2000, and watching the debug messages can be useful 
 
 Whenever the values of the Ethereum Service Provider keys are updated in an environment it is suggested to temporarily set DEBUG_ETHEREUM_FAIL_ON_ERROR to true and to watch the console messages on startup. If the app reports that all keys are valid and does not exit, then remove the environment variable prior to a final deploy.
 
+- ETHERSCAN_PAGE_SIZE - overrides the number of ERC20 transfer records fetched per page when using Etherscan for token discovery (default: 1000, maximum enforced by Etherscan). Set to a small value like 5 when testing pagination behavior against a wallet with many transactions, e.g. `ETHERSCAN_PAGE_SIZE=5 DEBUG_ETHEREUM=true yarn test-live`.
+
 ## Live Testing
 
 There is a script, `get-balances.ts`, that can be invoked to invoke the client against a real or test wallet. This mimics the behavior of the Lunch Money server when a user attempts to connect an Ethereum wallet. 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/lunch-money/ethereum-to-lunch-money/issues"
   },
   "homepage": "https://github.com/lunch-money/ethereum-to-lunch-money#README",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "keywords": [
     "lunch money",

--- a/src/client.ts
+++ b/src/client.ts
@@ -168,6 +168,7 @@ export class MoralisProvider {
 export const createEthereumWalletClient = (
   serviceProviderInfo: ProviderInfo[] = [],
   walletAPIProviderInfo: ProviderInfo[] = [],
+  getTokensBalanceFn: typeof ethscan.getTokensBalance = ethscan.getTokensBalance,
 ): EthereumWalletClient => {
   let providers: ReadonlyArray<ProviderInfo> = [];
   let etherscanProvider: EtherscanProvider | null = null;
@@ -285,7 +286,7 @@ export const createEthereumWalletClient = (
 
           debug(`Wallet ${obscuredWalletAddress}: Checking balances for ETH and ${filteredTokens.length} other tokens`);
 
-          const map = await ethscan.getTokensBalance(
+          const map = await getTokensBalanceFn(
             customProvider,
             walletAddress,
             filteredTokens.map((t) => t.address),
@@ -387,7 +388,7 @@ export const createEthereumWalletClient = (
     },
     async getTokensBalance(walletAddress: string, tokenContractAddresses: string[], providerInfo: ProviderInfo) {
       if (providerInfo.customProvider) {
-        return ethscan.getTokensBalance(providerInfo.customProvider, walletAddress, tokenContractAddresses);
+        return getTokensBalanceFn(providerInfo.customProvider, walletAddress, tokenContractAddresses);
       } else {
         throw new Error(`No ethscan compatible provider found for ${providerInfo.name}`);
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,7 +90,19 @@ export class EtherscanProvider {
         uniqueTokens.add(tx.contractAddress);
       }
 
-      if (data.result.length < pageSize || page >= 10) {
+      if (data.result.length < pageSize) {
+        break;
+      }
+
+      // Etherscan enforces a hard maximum of 10 pages: page 11 always returns
+      // "Result window is too large" regardless of offset size. This is not
+      // configurable — it applies even with ETHERSCAN_PAGE_SIZE=5 (50 records total).
+      // Wallets with more than 10 * pageSize transfer events will have older
+      // token history truncated here; Moralis (primary provider) does not have this limit.
+      if (page >= 10) {
+        debug(
+          `Etherscan: reached 10-page hard limit for ${obscuredAddress} — token discovery may be incomplete for high-activity wallets`,
+        );
         break;
       }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,14 +56,22 @@ export class EtherscanProvider {
     const targetChainId = chainId ? Number(chainId) : 1;
     const pageSize = process.env.ETHERSCAN_PAGE_SIZE ? parseInt(process.env.ETHERSCAN_PAGE_SIZE) : 1000;
     const uniqueTokens = new Set<string>();
+    const obscuredAddress = `0x..${address.slice(-6)}`;
     let page = 1;
+    let totalEvents = 0;
 
     while (true) {
-      const response = await this.fetchFn(
-        `${this.baseUrl}?chainid=${targetChainId}&module=account&action=tokentx&address=${address}&startblock=0&endblock=99999999&sort=desc&page=${page}&offset=${pageSize}&apikey=${this.apiKey}`,
-      );
+      const url = `${this.baseUrl}?chainid=${targetChainId}&module=account&action=tokentx&address=${address}&startblock=0&endblock=99999999&sort=desc&page=${page}&offset=${pageSize}&apikey=${this.apiKey}`;
 
-      const data = await response.json();
+      let data: { status: string; message: string; result: { contractAddress: string }[] };
+      try {
+        const response = await this.fetchFn(url);
+        data = (await response.json()) as typeof data;
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message.replace(/apikey=[^&\s]+/gi, 'apikey=[redacted]') : String(error);
+        throw new Error(`Etherscan API network error on page ${page} for ${obscuredAddress}: ${msg}`);
+      }
 
       if (data.status === '0' && data.message === 'No transactions found') {
         break;
@@ -77,6 +85,7 @@ export class EtherscanProvider {
         throw new Error(`Etherscan V2 API error: ${data.message}`);
       }
 
+      totalEvents += data.result.length;
       for (const tx of data.result) {
         uniqueTokens.add(tx.contractAddress);
       }
@@ -88,9 +97,12 @@ export class EtherscanProvider {
       // Stay under Etherscan's free tier limit of 3 calls/sec
       await new Promise((resolve) => setTimeout(resolve, 400));
       page++;
-      debug(`Etherscan: fetching page ${page} for address ${address}`);
+      debug(`Etherscan: fetching page ${page} for ${obscuredAddress}`);
     }
 
+    debug(
+      `Etherscan: fetched ${totalEvents} transfer events across ${page} page(s), discovered ${uniqueTokens.size} unique tokens for ${obscuredAddress}`,
+    );
     return Array.from(uniqueTokens);
   }
 }
@@ -372,7 +384,11 @@ export const createEthereumWalletClient = (
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           debug(`Error getting balances using provider ${providerName}: ${errorMessage}`);
-          if (errorMessage.includes('unconfigured name') || errorMessage.includes('bad address checksum')) {
+          if (
+            errorMessage.includes('unconfigured name') ||
+            errorMessage.includes('bad address checksum') ||
+            errorMessage.includes('invalid ENS name')
+          ) {
             throw new Error(`Invalid wallet address. Account needs to be relinked.`);
           } else if (providerIndex === providers.length - 1) {
             throw error;

--- a/src/client.ts
+++ b/src/client.ts
@@ -45,39 +45,50 @@ export interface EthereumWalletClient {
 export class EtherscanProvider {
   private apiKey: string;
   private baseUrl: string = 'https://api.etherscan.io/v2/api';
+  private fetchFn: typeof fetch;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, fetchFn: typeof fetch = fetch) {
     this.apiKey = apiKey;
+    this.fetchFn = fetchFn;
   }
 
   async discoverTokensForWallet(address: string, chainId?: bigint): Promise<string[]> {
-    // Use chainId from provider, default to Ethereum mainnet (1)
     const targetChainId = chainId ? Number(chainId) : 1;
-
-    const response = await fetch(
-      `${this.baseUrl}?chainid=${targetChainId}&module=account&action=tokentx&address=${address}&startblock=0&endblock=99999999&sort=desc&apikey=${this.apiKey}`,
-    );
-
-    const data = await response.json();
-
-    // Handle valid "no transactions" response
-    if (data.status === '0' && data.message === 'No transactions found') {
-      return [];
-    }
-
-    // Handle API errors
-    if (data.status === '0' && data.message === 'NOTOK') {
-      throw new Error(`Etherscan V2 API error: ${data.result}`);
-    }
-
-    if (data.status !== '1') {
-      throw new Error(`Etherscan V2 API error: ${data.message}`);
-    }
-
-    // Extract unique token contract addresses from transfer events
+    const pageSize = process.env.ETHERSCAN_PAGE_SIZE ? parseInt(process.env.ETHERSCAN_PAGE_SIZE) : 1000;
     const uniqueTokens = new Set<string>();
-    for (const tx of data.result) {
-      uniqueTokens.add(tx.contractAddress);
+    let page = 1;
+
+    while (true) {
+      const response = await this.fetchFn(
+        `${this.baseUrl}?chainid=${targetChainId}&module=account&action=tokentx&address=${address}&startblock=0&endblock=99999999&sort=desc&page=${page}&offset=${pageSize}&apikey=${this.apiKey}`,
+      );
+
+      const data = await response.json();
+
+      if (data.status === '0' && data.message === 'No transactions found') {
+        break;
+      }
+
+      if (data.status === '0' && data.message === 'NOTOK') {
+        throw new Error(`Etherscan V2 API error: ${data.result}`);
+      }
+
+      if (data.status !== '1') {
+        throw new Error(`Etherscan V2 API error: ${data.message}`);
+      }
+
+      for (const tx of data.result) {
+        uniqueTokens.add(tx.contractAddress);
+      }
+
+      if (data.result.length < pageSize || page >= 10) {
+        break;
+      }
+
+      // Stay under Etherscan's free tier limit of 3 calls/sec
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      page++;
+      debug(`Etherscan: fetching page ${page} for address ${address}`);
     }
 
     return Array.from(uniqueTokens);
@@ -383,6 +394,7 @@ export const createEthereumWalletClient = (
     },
     async discoverTokensHybrid(walletAddress: string, chainId: bigint): Promise<string[]> {
       const allTokens = new Set<string>();
+      let discoverySucceeded = false;
 
       // 1. Moralis Discovery (PRIMARY)
       if (moralisProvider) {
@@ -390,6 +402,7 @@ export const createEthereumWalletClient = (
           const moralisTokens = await moralisProvider.discoverTokensForWallet(walletAddress, chainId);
           debug(`Moralis: Discovered ${moralisTokens.length} tokens`);
           moralisTokens.forEach((t) => allTokens.add(t));
+          discoverySucceeded = true;
         } catch (error) {
           debug(`Moralis: Failed - ${error instanceof Error ? error.message : String(error)}`);
 
@@ -399,6 +412,7 @@ export const createEthereumWalletClient = (
               const etherscanTokens = await etherscanProvider.discoverTokensForWallet(walletAddress, chainId);
               debug(`Etherscan (fallback): Discovered ${etherscanTokens.length} tokens`);
               etherscanTokens.forEach((t) => allTokens.add(t));
+              discoverySucceeded = true;
             } catch (fallbackError) {
               debug(
                 `Etherscan (fallback): Failed - ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`,
@@ -417,12 +431,17 @@ export const createEthereumWalletClient = (
             const etherscanTokens = await etherscanProvider.discoverTokensForWallet(walletAddress, chainId);
             debug(`Etherscan: Discovered ${etherscanTokens.length} tokens`);
             etherscanTokens.forEach((t) => allTokens.add(t));
+            discoverySucceeded = true;
           } catch (error) {
             debug(`Etherscan: Failed - ${error instanceof Error ? error.message : String(error)}`);
           }
         } else {
           debug('Etherscan: No API key provided');
         }
+      }
+
+      if (!discoverySucceeded) {
+        throw new Error('All token discovery providers failed');
       }
 
       return Array.from(allTokens);

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -78,6 +78,35 @@ describe('createEthereumWalletClient', () => {
       });
     });
 
+    describe('when the wallet address is invalid', () => {
+      it('throws a clean error for non-Ethereum addresses (e.g. base64-encoded values)', async () => {
+        const badProvider = {
+          getBalance: sinon
+            .stub()
+            .rejects(
+              new Error(
+                'invalid ENS name (disallowed character: "+" {2B}) (argument="name", value="tEh2qOJbTagSEKa2wOJSpFfwb6zkQ4+42mgmUc1DgennWAdgBilvqeDK8oeJrAeWOO7uuy5ZqoOEz7MRuMlNbw==", code=INVALID_ARGUMENT, version=6.16.0)',
+              ),
+            ),
+          getNetwork: sinon.stub().resolves({ chainId: BigInt(chainIds.mainnet) }),
+          call: sinon.stub().resolves('0x'),
+        } as unknown as AbstractProvider;
+        const getTokensBalance = sinon.stub().resolves({});
+        const client = createEthereumWalletClient(makeServiceProviderInfo(badProvider), [], getTokensBalance);
+
+        try {
+          await client.getBalances(
+            'tEh2qOJbTagSEKa2wOJSpFfwb6zkQ4+42mgmUc1DgennWAdgBilvqeDK8oeJrAeWOO7uuy5ZqoOEz7MRuMlNbw==',
+            NEGLIGIBLE_BALANCE_THRESHOLD,
+          );
+          assert.fail('Expected error was not thrown');
+        } catch (error) {
+          assert.instanceOf(error, Error);
+          assert.match((error as Error).message, /Invalid wallet address/);
+        }
+      });
+    });
+
     describe('with respect to chains', () => {
       it('should support chains outside of mainnet', async () => {
         const getTokensBalance = sinon.stub().resolves({});

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,52 +1,60 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { AbstractProvider } from 'ethers';
 
-import { LunchMoneyEthereumWalletConnection as underTest } from '../src/main.js';
-import { EtherscanProvider } from '../src/client.js';
+import { createEthereumWalletClient, EtherscanProvider } from '../src/client.js';
 
 enum chainIds {
   'mainnet' = 1,
   'base' = 8453,
 }
 
-describe('LunchMoneyEthereumWalletConnection', () => {
-  const dummyConfig = {
-    walletAddress: '0xfoo',
-    negligibleBalanceThreshold: 100,
-  };
+const TEST_WALLET = '0x0000000000000000000000000000000000000001';
+const NEGLIGIBLE_BALANCE_THRESHOLD = 100;
 
-  const mockClient = {
-    getChainId: sinon.stub(),
-    getWeiBalance: sinon.stub(),
-    getTokensBalance: sinon.stub(),
-  };
-  const dummyContext = {
-    client: mockClient,
-  };
+const makeProvider = (weiBalance: bigint, chainId: bigint) =>
+  ({
+    getBalance: sinon.stub().resolves(weiBalance),
+    getNetwork: sinon.stub().resolves({ chainId }),
+    call: sinon.stub().resolves('0x'),
+  }) as unknown as AbstractProvider;
 
+const makeServiceProviderInfo = (provider: AbstractProvider) => [
+  {
+    type: 'Service Provider' as const,
+    name: 'Test',
+    status: 'SUCCESS' as const,
+    provider,
+  },
+];
+
+describe('createEthereumWalletClient', () => {
   describe('getBalances', () => {
     describe('when the wallet has an ETH amount less than the negligible balance threshold', () => {
       it('does not output the ETH balance amount', async () => {
-        mockClient.getChainId.resolves(chainIds.mainnet);
-        mockClient.getWeiBalance.resolves(50);
-        mockClient.getTokensBalance.resolves({});
+        const getTokensBalance = sinon.stub().resolves({});
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(50), BigInt(chainIds.mainnet))),
+          [],
+          getTokensBalance,
+        );
 
-        const response = await underTest.getBalances(dummyConfig, dummyContext);
+        const response = await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
 
-        assert.deepEqual(response, {
-          providerName: 'wallet_ethereum',
-          balances: [],
-        });
+        assert.deepEqual(response, { providerName: 'wallet_ethereum', balances: [] });
       });
     });
 
     describe('when the wallet has an ETH amount more than the negligible balance threshold', () => {
       it('outputs the ETH balance amount', async () => {
-        mockClient.getChainId.resolves(chainIds.mainnet);
-        mockClient.getWeiBalance.resolves(1000);
-        mockClient.getTokensBalance.resolves({});
+        const getTokensBalance = sinon.stub().resolves({});
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(1000), BigInt(chainIds.mainnet))),
+          [],
+          getTokensBalance,
+        );
 
-        const response = await underTest.getBalances(dummyConfig, dummyContext);
+        const response = await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
 
         assert.deepEqual(response, {
           providerName: 'wallet_ethereum',
@@ -57,28 +65,29 @@ describe('LunchMoneyEthereumWalletConnection', () => {
 
     describe('when the wallet contains no tokens', () => {
       it('outputs nothing', async () => {
-        mockClient.getChainId.resolves(chainIds.mainnet);
-        mockClient.getWeiBalance.resolves(0);
-        mockClient.getTokensBalance.resolves({});
+        const getTokensBalance = sinon.stub().resolves({});
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(0), BigInt(chainIds.mainnet))),
+          [],
+          getTokensBalance,
+        );
 
-        const response = await underTest.getBalances(dummyConfig, dummyContext);
+        const response = await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
 
-        assert.deepEqual(response, {
-          providerName: 'wallet_ethereum',
-          balances: [],
-        });
+        assert.deepEqual(response, { providerName: 'wallet_ethereum', balances: [] });
       });
     });
 
     describe('with respect to chains', () => {
       it('should support chains outside of mainnet', async () => {
-        mockClient.getChainId.resolves(chainIds.base); // Base Chain
-        mockClient.getWeiBalance.resolves(50);
-        mockClient.getTokensBalance.resolves({
-          '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee': 1000, // ETH on Base
-        });
+        const getTokensBalance = sinon.stub().resolves({});
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(1000), BigInt(chainIds.base))),
+          [],
+          getTokensBalance,
+        );
 
-        const response = await underTest.getBalances(dummyConfig, dummyContext);
+        const response = await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
 
         assert.deepEqual(response, {
           providerName: 'wallet_ethereum',
@@ -87,41 +96,39 @@ describe('LunchMoneyEthereumWalletConnection', () => {
       });
 
       it('should throw an error if a returned token is not on the chain specified', async () => {
-        mockClient.getChainId.resolves(chainIds.base);
-        mockClient.getWeiBalance.resolves(50);
-        mockClient.getTokensBalance.resolves({
-          '0x3c3a81e81dc49a522a592e7622a7e711c06bf354': 1000, // MNT on mainnet
+        const getTokensBalance = sinon.stub().resolves({
+          '0x3c3a81e81dc49a522a592e7622a7e711c06bf354': BigInt(1000), // MNT — mainnet only, not on Base
         });
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(50), BigInt(chainIds.base))),
+          [],
+          getTokensBalance,
+        );
 
-        // Expect an error to be thrown
-        const errorNotThownMessage = 'Expected error was not thrown';
         try {
-          await underTest.getBalances(dummyConfig, dummyContext);
-          assert.fail(errorNotThownMessage); // Fail the test if no error is thrown
+          await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
+          assert.fail('Expected error was not thrown');
         } catch (error) {
           assert.instanceOf(error, Error);
-          if (errorNotThownMessage === error.message) {
-            assert.fail(errorNotThownMessage);
-          }
-          assert.equal(
-            error.message,
-            'Token 0x3c3a81e81dc49a522a592e7622a7e711c06bf354 not found in filtered token list for chainId 8453',
-          );
+          assert.match((error as Error).message, /Token 0x3c3a81e81dc49a522a592e7622a7e711c06bf354 not found/);
         }
       });
     });
 
     describe('when the wallet contains tokens', () => {
       it('outputs the tokens which have balances above the negligible balance threshold', async () => {
-        mockClient.getChainId.resolves(chainIds.mainnet);
-        mockClient.getWeiBalance.resolves(50);
-        mockClient.getTokensBalance.resolves({
-          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 100, // USDC which has 6 decimals
-          '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2': 100, // MKR which has 18 decimals
-          '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': 100, // WBTC which has 8 decimals
+        const getTokensBalance = sinon.stub().resolves({
+          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': BigInt(100), // USDC — 6 decimals
+          '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2': BigInt(100), // MKR — 18 decimals (below threshold)
+          '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599': BigInt(100), // WBTC — 8 decimals
         });
+        const client = createEthereumWalletClient(
+          makeServiceProviderInfo(makeProvider(BigInt(50), BigInt(chainIds.mainnet))),
+          [],
+          getTokensBalance,
+        );
 
-        const response = await underTest.getBalances(dummyConfig, dummyContext);
+        const response = await client.getBalances(TEST_WALLET, NEGLIGIBLE_BALANCE_THRESHOLD);
 
         assert.strictEqual(response.providerName, 'wallet_ethereum');
         assert.sameDeepMembers(response.balances, [

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 
 import { LunchMoneyEthereumWalletConnection as underTest } from '../src/main.js';
+import { EtherscanProvider } from '../src/client.js';
 
 enum chainIds {
   'mainnet' = 1,
@@ -128,6 +129,82 @@ describe('LunchMoneyEthereumWalletConnection', () => {
           { asset: 'WBTC', amount: '0.000001' },
         ]);
       });
+    });
+  });
+});
+
+describe('EtherscanProvider', () => {
+  const makePage = (count: number, prefix = '0xtoken') =>
+    Array.from({ length: count }, (_, i) => ({ contractAddress: `${prefix}${i}` }));
+
+  const makeResponse = (result: object[], status = '1', message = 'OK') =>
+    Promise.resolve({ json: () => Promise.resolve({ status, message, result }) });
+
+  afterEach(() => sinon.restore());
+
+  describe('discoverTokensForWallet', () => {
+    it('returns an empty array when there are no transactions', async () => {
+      const mockFetch = sinon.stub().returns(makeResponse([], '0', 'No transactions found'));
+      const provider = new EtherscanProvider('test-key', mockFetch);
+
+      const tokens = await provider.discoverTokensForWallet('0xwallet');
+
+      assert.equal(mockFetch.callCount, 1);
+      assert.deepEqual(tokens, []);
+    });
+
+    it('returns unique token addresses from a single page', async () => {
+      const result = [
+        { contractAddress: '0xaaa' },
+        { contractAddress: '0xbbb' },
+        { contractAddress: '0xaaa' }, // duplicate
+      ];
+      const mockFetch = sinon.stub().returns(makeResponse(result));
+      const provider = new EtherscanProvider('test-key', mockFetch);
+
+      const tokens = await provider.discoverTokensForWallet('0xwallet');
+
+      assert.equal(mockFetch.callCount, 1);
+      assert.sameMembers(tokens, ['0xaaa', '0xbbb']);
+    });
+
+    it('paginates when a full page is returned', async () => {
+      const mockFetch = sinon.stub();
+      mockFetch.onFirstCall().returns(makeResponse(makePage(1000)));
+      mockFetch.onSecondCall().returns(makeResponse(makePage(3, '0xpage2token')));
+      const provider = new EtherscanProvider('test-key', mockFetch);
+
+      const tokens = await provider.discoverTokensForWallet('0xwallet');
+
+      assert.equal(mockFetch.callCount, 2);
+      assert.equal(tokens.length, 1003);
+      assert.include(tokens, '0xpage2token0');
+    });
+
+    it('stops paginating when a page returns fewer results than the page size', async () => {
+      const mockFetch = sinon.stub();
+      mockFetch.onFirstCall().returns(makeResponse(makePage(1000)));
+      mockFetch.onSecondCall().returns(makeResponse(makePage(1000, '0xp2')));
+      mockFetch.onThirdCall().returns(makeResponse(makePage(42, '0xp3')));
+      const provider = new EtherscanProvider('test-key', mockFetch);
+
+      const tokens = await provider.discoverTokensForWallet('0xwallet');
+
+      assert.equal(mockFetch.callCount, 3);
+      assert.equal(tokens.length, 2042);
+    });
+
+    it('throws on a NOTOK API error', async () => {
+      const mockFetch = sinon.stub().returns(makeResponse([], '0', 'NOTOK'));
+      const provider = new EtherscanProvider('test-key', mockFetch);
+
+      try {
+        await provider.discoverTokensForWallet('0xwallet');
+        assert.fail('Expected error was not thrown');
+      } catch (error) {
+        assert.instanceOf(error, Error);
+        assert.match((error as Error).message, /Etherscan V2 API error/);
+      }
     });
   });
 });


### PR DESCRIPTION
The ethereum plugin uses the Moralis and Etherscan libraries to pull the transaction history associated with an etheruem wallet.  Prior to doing this we just checked the balance of every possible currency.  Now, with the transaction history, we can quickly determine the list of currencies in a wallet and pull only the balances for those currencies, allowing us to remain on the free tier for our Ethereum services.

Starting July 1, Etherscan will only return 10K transactions at a time.  This is probably fine for most Lunch Money connected wallets, but users with a lot of currencies may hit that limit and we many not update a balance for some of their less traded currencies. 

This PR simply adds pagination when there are more than 1K transactions associated with a wallet.  We stop at 10K transactions.  Updated logging captures when this pagination occurs.